### PR TITLE
Set default values to parameters of the CupIcon component

### DIFF
--- a/src/components/common/CupIcon.jsx
+++ b/src/components/common/CupIcon.jsx
@@ -1,26 +1,26 @@
-import Image from "next/image";
+import Image from 'next/image'
 
-const CupIcon = ({src, alt, width, height}) => (
-        <Image
-            src={src}
-            alt={alt}
-            width={width}
-            height={height}
-        />
-);
+const CupIcon = ({ src, alt, width, height }) => (
+  <Image
+    src={src}
+    alt={alt}
+    width={width}
+    height={height}
+  />
+)
 
-const CupIconContainer = ({food, width, height}) => {
-    const src = food === "" ? "/icons/cup.png": `/icons/cup-${food}.png`;
-    const alt = food === "" ? "cup icon" : `${food} cup icon`;
+const CupIconContainer = ({ food = '', width = 100, height = 100 }) => {
+  const src = food === '' ? '/icons/cup.png' : `/icons/cup-${food}.png`
+  const alt = food === '' ? 'cup icon' : `${food} cup icon`
 
-    return (
-        <CupIcon
-            src={src}
-            alt={alt}
-            width={width || 100}
-            height={height || 100}
-        />
-    );
-};
+  return (
+    <CupIcon
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+    />
+  )
+}
 
-export default CupIconContainer;
+export default CupIconContainer


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Added default values to the props of `CupIconContainer`
- Remove `|| 100` from the props passed to `CupIcon`

#### Issues affected

- Fixes #29

## Additional Info

- The same code modification is also mentioned in #27
- This PR requires no reviews since the same code modification is approved in the PR above.

## Testing Plan

- Check if the component's default values and passed props work in the browser

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)