### PR TITLE
Modifid Customize main to fit in LP and customize pages

### DIFF
--- a/src/components/pages/Customize/CustomizeMain.jsx
+++ b/src/components/pages/Customize/CustomizeMain.jsx
@@ -7,7 +7,7 @@ import styles from '@/styles/pages/customize.module.scss'
 
 // CustomizeMain. This component is place in componentsfolder because this will be reused in LP page.
 const CustomizeMain = ({ iconName, title, description, optionNames }) => (
-  <div>
+  <div className={styles.customizeContainer}>
     <CustomizeUpper
       iconName={iconName}
       title={title}

--- a/src/styles/pages/customize.module.scss
+++ b/src/styles/pages/customize.module.scss
@@ -3,9 +3,16 @@
 
 .customize {
 
+    &Container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
     &UpperSec {
         width: 100%;
         display: flex;
+        justify-content: center;
 
         @include m.tablet {
             flex-direction: column;
@@ -42,10 +49,16 @@
 
     &LowerSec {
         width: 100%;
-        max-width: 600px;
+        max-width: 500px;
         margin-top: 20px;
 
+        & h3 {
+            text-align: start;
+        }
+
         @include m.tablet {
+
+            max-width: 400px;
 
             & h3 {
                 text-align: center;


### PR DESCRIPTION
## Proposed Changes

Modified styles of Customize component.

#### Code changes
- Modified  styles of Customize component
- Check if UI is not collapsed in LP and Customize page

#### Issues affected
- Fixes #58

## Additional Info

## Screenshots and/or video

<img width="1371" alt="Screen Shot 2023-01-19 at 4 06 15 PM" src="https://user-images.githubusercontent.com/55787141/213589386-53dc24f1-2c5a-42fe-9cf4-8c1a05f55c83.png">

<img width="1362" alt="Screen Shot 2023-01-19 at 4 06 45 PM" src="https://user-images.githubusercontent.com/55787141/213589423-916e0ab8-ea85-463a-abe7-5b439429e3bf.png">


## Testing Plan

## Checklist


#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)