### PR TITLE
Fix Footer to the bottom of the page

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -6,15 +6,13 @@ import styles from '@/styles/pages/home.module.scss'
 
 const HomePage = () => (
   <PageLayout>
-    <div className={styles.container}>
-      <Link href='/drink/select'>
-        <CupIcon
-          width={250}
-          height={250}
-        />
-        <p className={styles.selectionName}>Mood</p>
-      </Link>
-    </div>
+    <Link href='/drink/select'>
+      <CupIcon
+        width={250}
+        height={250}
+      />
+      <p className={styles.selectionName}>Mood</p>
+    </Link>
   </PageLayout>
 )
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -6,13 +6,15 @@ import styles from '@/styles/pages/home.module.scss'
 
 const HomePage = () => (
   <PageLayout>
-    <Link href='/drink/select'>
-      <CupIcon
-        width={250}
-        height={250}
-      />
-      <p className={styles.selectionName}>Mood</p>
-    </Link>
+    <div className={styles.container}>
+      <Link href='/drink/select'>
+        <CupIcon
+          width={250}
+          height={250}
+        />
+        <p className={styles.selectionName}>Mood</p>
+      </Link>
+    </div>
   </PageLayout>
 )
 

--- a/src/styles/common/pageLayout/pageLayout.module.scss
+++ b/src/styles/common/pageLayout/pageLayout.module.scss
@@ -1,6 +1,7 @@
 .pageLayout {
   &Content {
     max-width: 90%;
+    min-height: 68vh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -2,7 +2,7 @@
 
 .container {
   width: 100%;
-  height: 68vh;
+  min-height: 68vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -1,14 +1,7 @@
 @use '@/styles/abstracts' as a;
 
-.container {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  .selectionName {
-    font-size: 32px;
-    color: a.$clrTextCommon;
-    text-align: center;
-  }
+.selectionName {
+  font-size: 32px;
+  color: a.$clrTextCommon;
+  text-align: center;
 }

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -1,8 +1,15 @@
 @use '@/styles/abstracts' as a;
 
-.selectionName {
-  font-size: 2rem;
-  color: a.$clrTextCommon;
-  text-align: center;
-  margin: 0;
+.container {
+  width: 100%;
+  height: 68vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .selectionName {
+    font-size: 32px;
+    color: a.$clrTextCommon;
+    text-align: center;
+  }
 }

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -2,7 +2,6 @@
 
 .container {
   width: 100%;
-  min-height: 68vh;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Add `min-height` to `<PageLayout />` to fix the footer to the bottom of the page
- Change `rem` to `px` in `home.module.scss`

#### Issues affected

- Fixes #60 

## Screenshots and/or video

### Before

![Image](https://user-images.githubusercontent.com/110521018/213597268-6ce3f2f1-eaa6-49eb-8c38-7196535f9b95.png)

### After

- About
![Create Next App](https://user-images.githubusercontent.com/110521018/213612019-9b1ad13f-b362-45d9-882a-b02f977c2ade.gif)

- Home
![home](https://user-images.githubusercontent.com/110521018/213612048-1e8b5d88-c7aa-49b5-b9c1-b86b92ed47d9.gif)

- Mood Select
![moodSelect](https://user-images.githubusercontent.com/110521018/213612075-d06ce8b6-4315-44ec-bff0-76b68fcec5e4.gif)

- Customize
![customize](https://user-images.githubusercontent.com/110521018/213612097-46746ff7-e4d9-4e87-99b6-58c4a1abb84d.gif)

## Additional memo

I checked all the pages with multiple widths for responsibility and found no design collapse

## Testing Plan

- Check the page layout with Google developer tools

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)