### PR TITLE
Convert Js to Ts: common components

### DIFF
--- a/src/components/common/CupIcon.tsx
+++ b/src/components/common/CupIcon.tsx
@@ -1,6 +1,10 @@
+import { FC } from 'react'
+
 import Image from 'next/image'
 
-const CupIcon = ({ src, alt, width, height }: any) => (
+import { IconProps, IconContainerProps } from './common.type'
+
+const CupIcon: FC<IconProps> = ({ src, alt, width, height }) => (
   <Image
     src={src}
     alt={alt}
@@ -9,9 +13,13 @@ const CupIcon = ({ src, alt, width, height }: any) => (
   />
 )
 
-const CupIconContainer = ({ food = '', width = 100, height = 100 }) => {
-  const src = food === '' ? '/icons/cup.png' : `/icons/cup-${food}.png`
-  const alt = food === '' ? 'cup icon' : `${food} cup icon`
+const CupIconContainer: FC<Omit<IconContainerProps, 'mood'>> = ({
+  food = '',
+  width = 100,
+  height = 100,
+}) => {
+  const src: string = food === '' ? '/icons/cup.png' : `/icons/cup-${food}.png`
+  const alt: string = food === '' ? 'cup icon' : `${food} cup icon`
 
   return (
     <CupIcon

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,6 +1,8 @@
+import { FC } from 'react'
+
 import styles from 'styles/common/Footer/Footer.module.scss'
 
-const Footer = () => (
+const Footer: FC = () => (
   <div className={styles['footer-container']}>
     <p className={styles['footer-content']}>
       &copy; 2023 Cafe Drink Customizer

--- a/src/components/common/Header/BurgerNavMenu.tsx
+++ b/src/components/common/Header/BurgerNavMenu.tsx
@@ -1,7 +1,10 @@
+import { FC } from 'react'
+
 import { NavContent } from '../../index'
+
 import styles from 'styles/common/Header/BurgerNavMenu.module.scss'
 
-const BurgerNavMenu = () => (
+const BurgerNavMenu: FC = () => (
   <ul className={styles['burger-nav-menu-container']}>
     <NavContent />
   </ul>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,8 +1,14 @@
-import React, { useState } from 'react'
+import React, { FC, useState } from 'react'
 import { HeaderLogo, NavMenu, BurgerNavMenu } from '../../index'
 import styles from 'styles/common/Header/Header.module.scss'
 
-const Header = ({ burgerClass, menuClass, updateMenu }: any) => (
+interface HeaderProps {
+  burgerClass: string
+  menuClass: string
+  updateMenu: () => void
+}
+
+const Header: FC<HeaderProps> = ({ burgerClass, menuClass, updateMenu }) => (
   <>
     <div className={styles['nav-bar']}>
       <HeaderLogo />
@@ -29,10 +35,13 @@ const Header = ({ burgerClass, menuClass, updateMenu }: any) => (
   </>
 )
 
-const HeaderContainer = () => {
-  const [burger_class, setBurgerClass] = useState('burger-bar')
-  const [menu_class, setMenuClass] = useState('menu-hidden')
-  const [isMenuClicked, setIsMenuClicked] = useState(false)
+const HeaderContainer: FC = () => {
+  const [burger_class, setBurgerClass]: [string, (param: string) => void] =
+    useState('burger-bar')
+  const [menu_class, setMenuClass]: [string, (param: string) => void] =
+    useState('menu-hidden')
+  const [isMenuClicked, setIsMenuClicked]: [boolean, (param: boolean) => void] =
+    useState(false)
 
   const updateMenu = () => {
     if (!isMenuClicked) {

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -9,30 +9,28 @@ interface HeaderProps {
 }
 
 const Header: FC<HeaderProps> = ({ burgerClass, menuClass, updateMenu }) => (
-  <>
-    <div className={styles['nav-bar']}>
-      <HeaderLogo />
+  <div className={styles['nav-bar']}>
+    <HeaderLogo />
 
-      <div
-        className={styles['burger-menu']}
-        onClick={updateMenu}
-      >
-        <div className={styles[burgerClass]}></div>
+    <div
+      className={styles['burger-menu']}
+      onClick={updateMenu}
+    >
+      <div className={styles[burgerClass]}></div>
 
-        <div className={styles[burgerClass]}></div>
+      <div className={styles[burgerClass]}></div>
 
-        <div className={styles[burgerClass]}></div>
-      </div>
-
-      <nav className={styles[menuClass]}>
-        <BurgerNavMenu />
-      </nav>
-
-      <nav className={styles['nav-menu']}>
-        <NavMenu />
-      </nav>
+      <div className={styles[burgerClass]}></div>
     </div>
-  </>
+
+    <nav className={styles[menuClass]}>
+      <BurgerNavMenu />
+    </nav>
+
+    <nav className={styles['nav-menu']}>
+      <NavMenu />
+    </nav>
+  </div>
 )
 
 const HeaderContainer: FC = () => {

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -34,13 +34,9 @@ const Header: FC<HeaderProps> = ({ burgerClass, menuClass, updateMenu }) => (
 )
 
 const HeaderContainer: FC = () => {
-  const [burger_class, setBurgerClass]: [string, (param: string) => void] =
-    useState('burger-bar')
-  const [menu_class, setMenuClass]: [string, (param: string) => void] =
-    useState('menu-hidden')
-  const [isMenuClicked, setIsMenuClicked]: [boolean, (param: boolean) => void] =
-    useState(false)
-
+  const [burger_class, setBurgerClass] = useState<string>('burger-bar')
+  const [menu_class, setMenuClass] = useState<string>('menu-hidden')
+  const [isMenuClicked, setIsMenuClicked] = useState<boolean>(false)
   const updateMenu = () => {
     if (!isMenuClicked) {
       setBurgerClass('burger-bar-clicked')

--- a/src/components/common/Header/HeaderLogo.tsx
+++ b/src/components/common/Header/HeaderLogo.tsx
@@ -1,8 +1,9 @@
+import { FC } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import styles from 'styles/common/Header/HeaderLogo.module.scss'
 
-const HeaderLogo = () => (
+const HeaderLogo: FC = () => (
   <div className={styles['logo-container']}>
     <Link
       className={styles['logo-link']}

--- a/src/components/common/Header/NavContent.tsx
+++ b/src/components/common/Header/NavContent.tsx
@@ -1,20 +1,24 @@
+import { FC } from 'react'
 import Link from 'next/link'
 import styles from 'styles/common/Header/NavContent.module.scss'
 
-const NAV_ITEMS = ['About']
-const NavContent = () =>
-  NAV_ITEMS.map((item, idx) => (
-    <li
-      className={styles['nav-content']}
-      key={idx}
-    >
-      <Link
-        className={styles['nav-content-link']}
-        href={`/${item.toLowerCase()}`}
+const NAV_ITEMS: string[] = ['About']
+const NavContent: FC = () => (
+  <>
+    {NAV_ITEMS.map((item: string, idx: number) => (
+      <li
+        className={styles['nav-content']}
+        key={idx}
       >
-        {item}
-      </Link>
-    </li>
-  ))
+        <Link
+          className={styles['nav-content-link']}
+          href={`/${item.toLowerCase()}`}
+        >
+          {item}
+        </Link>
+      </li>
+    ))}
+  </>
+)
 
 export default NavContent

--- a/src/components/common/Header/NavMenu.tsx
+++ b/src/components/common/Header/NavMenu.tsx
@@ -1,7 +1,8 @@
+import { FC } from 'react'
 import { NavContent } from '../../index'
 import styles from 'styles/common/Header/NavMenu.module.scss'
 
-const NavMenu = () => (
+const NavMenu: FC = () => (
   <ul className={styles['nav-menu-container']}>
     <NavContent />
   </ul>

--- a/src/components/common/LinkButton/LinkButton.tsx
+++ b/src/components/common/LinkButton/LinkButton.tsx
@@ -1,7 +1,13 @@
+import { FC } from 'react'
 import Link from 'next/link'
 import styles from 'styles/common/Button/Button.module.scss'
 
-const LinkButton = ({ buttonContent, link }: any) => (
+interface LinkButtonProps {
+  buttonContent: string
+  link: string
+}
+
+const LinkButton: FC<LinkButtonProps> = ({ buttonContent, link }) => (
   <div className={styles['button-container']}>
     <Link
       className={styles['button-link']}

--- a/src/components/common/MoodIcon.tsx
+++ b/src/components/common/MoodIcon.tsx
@@ -1,19 +1,10 @@
+import { FC } from 'react'
+
 import Image from 'next/image'
 
-interface MoodIconProps {
-  src: string
-  alt: string
-  width: number
-  height: number
-}
+import { IconProps, IconContainerProps } from './common.type'
 
-interface MoodIconContainerProps {
-  mood?: string
-  width?: number
-  height?: number
-}
-
-const MoodIcon = ({ src, alt, width, height }: MoodIconProps) => (
+const MoodIcon: FC<IconProps> = ({ src, alt, width, height }) => (
   <Image
     src={src}
     alt={alt}
@@ -22,13 +13,13 @@ const MoodIcon = ({ src, alt, width, height }: MoodIconProps) => (
   />
 )
 
-const MoodIconContainer = ({
+const MoodIconContainer: FC<Omit<IconContainerProps, 'food'>> = ({
   mood = '',
   width = 100,
   height = 100,
-}: MoodIconContainerProps) => {
-  const src = `/icons/${mood}.png`
-  const alt = `${mood} icon`
+}) => {
+  const src: string = `/icons/${mood}.png`
+  const alt: string = `${mood} icon`
 
   return (
     <MoodIcon

--- a/src/components/common/banner/Banner.tsx
+++ b/src/components/common/banner/Banner.tsx
@@ -1,17 +1,23 @@
-import { useRouter } from 'next/router'
+import { FC } from 'react'
+
+import { useRouter, NextRouter } from 'next/router'
 
 import styles from 'styles/common/banner/banner.module.scss'
 
-const Banner = ({ content }: any) => (
+interface BannerProps {
+  content: JSX.Element
+}
+
+const Banner: FC<BannerProps> = ({ content }) => (
   <div className={styles['banner']}>
     <div className={styles['banner-content']}>{content}</div>
   </div>
 )
 
-const BannerContainer = () => {
-  const Router = useRouter()
-  const Path = Router.pathname
-  const Content =
+const BannerContainer: FC = () => {
+  const Router: NextRouter = useRouter()
+  const Path: string = Router.pathname
+  const Content: JSX.Element =
     Path === '/about' ? (
       <>
         <h1 className={styles['banner-title1']}>

--- a/src/components/common/common.type.ts
+++ b/src/components/common/common.type.ts
@@ -1,0 +1,13 @@
+export interface IconProps {
+  src: string
+  alt: string
+  width: number
+  height: number
+}
+
+export interface IconContainerProps {
+  food: string
+  mood: string
+  width: number
+  height: number
+}

--- a/src/components/common/pageLayout/PageLayout.tsx
+++ b/src/components/common/pageLayout/PageLayout.tsx
@@ -1,9 +1,14 @@
-import React from 'react'
+import React, { FC, ReactNode } from 'react'
+
 import { Header, Banner, Footer } from '../../index'
 
 import styles from 'styles/common/pageLayout/pageLayout.module.scss'
 
-const PageLayout = ({ children }: any) => (
+interface PageLayoutProps {
+  children: ReactNode
+}
+
+const PageLayout: FC<PageLayoutProps> = ({ children }) => (
   <div>
     <Header />
 


### PR DESCRIPTION
## Proposed Changes

- This PR solves the conversion of the common components from JS to TS.

#### Code changes

- Created a type file for commonly used types `common.type.ts`
- Added the data types `FC` or `FC<>` to the components to specify that they are Function Components
- Added data types with interfaces to the props of the components
- Added matching data type to constants in the components
- Removed unnecessary React Fragment in `Header.tsx`
- Added React Fragment to `NavContent.tsx` to solve Error TS(2786)

#### Issues affected

- Resolves #75

## Additional Info

- I added  the`FC` type to every function component for readability but let me know if those `FC` types are unnecessary or make the code harder to read
- Let me know if the data types added to constants and return values of hooks are unnecessary

## Screenshots and/or video

- none

## Testing Plan

- Check if there is no compile error shown on `npm run dev`

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)