### PR TITLE
Convert JS to TS: About components

### DIFF
--- a/src/components/common/common.type.ts
+++ b/src/components/common/common.type.ts
@@ -6,7 +6,7 @@ export interface IconProps {
 }
 
 export interface IconContainerProps {
-  food: string
+  food?: string
   mood: string
   width: number
   height: number

--- a/src/components/pages/About/AboutAppDescription.tsx
+++ b/src/components/pages/About/AboutAppDescription.tsx
@@ -1,6 +1,8 @@
+import { FC } from 'react'
+
 import styles from 'styles/pages/about.module.scss'
 
-const AboutAppDescription = () => (
+const AboutAppDescription: FC = () => (
   <div className={styles['container']}>
     <div className={styles['text-container']}>
       <p className={styles['text']}>

--- a/src/components/pages/About/AboutSectionLayout.tsx
+++ b/src/components/pages/About/AboutSectionLayout.tsx
@@ -1,6 +1,18 @@
+import { FC, ReactNode } from 'react'
+
 import styles from 'styles/pages/about.module.scss'
 
-const AboutSectionLayout = ({ title = '', description, children }: any) => {
+interface AboutSectionLayoutProps {
+  title?: string
+  description?: string
+  children: ReactNode
+}
+
+const AboutSectionLayout: FC<AboutSectionLayoutProps> = ({
+  title = '',
+  description,
+  children,
+}) => {
   return (
     <section className={styles.sectionLayout}>
       <div className={styles.titleContainer}>

--- a/src/components/pages/About/SectionTypeList.tsx
+++ b/src/components/pages/About/SectionTypeList.tsx
@@ -1,12 +1,14 @@
+import { FC } from 'react'
+
 import { CupIcon } from 'components'
 
 import styles from 'styles/pages/about.module.scss'
 
 const SECTION_TYPES = ['MOOD', 'FLAVOR', 'MENU']
 
-const SectionTypeList = () => (
+const SectionTypeList: FC = () => (
   <div className={styles.sectionTypes}>
-    {SECTION_TYPES.map((type, idx) => (
+    {SECTION_TYPES.map((type: string, idx: number) => (
       <div
         className={styles.sectionType}
         key={idx}


### PR DESCRIPTION
## Proposed Changes

- This PR solves the conversion of the About components from JS to TS.

#### Code changes

- Added the data type `FC` to the components to specify that they are Function Components
- Added data types with interfaces to the props of the components
- Updated `food` in `IconContainerProps` to optional props to fix an error of missing required props

#### Issues affected

- Resolves #85

## Additional Info

- none

## Screenshots and/or video

- none

## Testing Plan

- Check if there is no compile error shown on `npm run dev`

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)